### PR TITLE
Add --serverless option to deploy.py for serverless job compute

### DIFF
--- a/02-tcga-expression-clustering-optimized.py
+++ b/02-tcga-expression-clustering-optimized.py
@@ -254,8 +254,6 @@ top_genes_df = (
     .limit(N_TOP_GENES)
 )
 
-# Cache for reuse
-top_genes_df.cache()
 top_genes_list = [row['gene_id'] for row in top_genes_df.select('gene_id').collect()]
 
 # Log gene variance statistics
@@ -295,10 +293,7 @@ pivot_df = (
     .agg(first('fpkm_unstranded'))
 )
 
-# Cache the pivoted dataframe
-pivot_df.cache()
-
-# Save pivoted data as checkpoint
+# Save pivoted data as checkpoint (also materializes the pivot)
 checkpoint_table = f"{database_name}.{user_id}_expression_profiles_pivoted"
 pivot_df.write.mode('overwrite').saveAsTable(checkpoint_table)
 

--- a/README.md
+++ b/README.md
@@ -16,16 +16,28 @@ cd hls-tcga
 # Run the deployment script (interactive setup)
 python deploy.py
 
-# Or deploy and run immediately
+# Or deploy and run immediately on classic job clusters
 python deploy.py --run
+
+# Or deploy and run on serverless compute (no cluster provisioning)
+python deploy.py --run --serverless
 ```
 
 The `deploy.py` script will:
 - Auto-detect your Databricks workspace and cloud provider
-- Prompt for configuration with intelligent defaults
+- Prompt for configuration with intelligent defaults (including compute mode)
 - Create Unity Catalog resources (catalog, schema, volume)
 - Deploy the complete pipeline to your workspace
 - Optionally run the workflow immediately
+
+#### Compute modes
+
+| Mode | How to select | What happens |
+|---|---|---|
+| **Classic clusters** (default) | `python deploy.py --run` | Provisions job clusters using `compute.*_node_type` from `config.json`. Uses bundle target `dev`. |
+| **Serverless** | `python deploy.py --run --serverless` | Notebook tasks run on serverless compute; no cluster provisioning. Uses bundle target `dev-serverless`. Persists `compute.use_serverless=true` to `config.json` so subsequent `--non-interactive` runs pick it up automatically. |
+
+The DLT pipeline (silver/gold layer) is always serverless regardless of the selected mode. On serverless, the download task's 64-core single-node profile is replaced with Databricks' auto-sized serverless compute — throughput may differ.
 
 ### Alternative: Direct Bundle Deployment
 
@@ -182,6 +194,21 @@ Configurable via Databricks widgets:
 - `n_top_genes`: Variable genes for analysis (default: 1000)
 - `n_pca_components`: PCA dimensions (default: 50)
 
+### `config.json` keys
+
+The `compute` section controls cluster provisioning:
+
+```json
+"compute": {
+  "use_serverless": false,            // true = use serverless; false = classic job clusters
+  "download_node_type": "r5d.16xlarge",
+  "etl_node_type": "r5d.2xlarge",
+  "analysis_node_type": "r5d.xlarge"
+}
+```
+
+Setting `use_serverless: true` (or passing `--serverless` once) makes `deploy.py` deploy to the `dev-serverless` bundle target; node type values are ignored in that mode but preserved so toggling back is seamless.
+
 ### Environment Variables
 
 ```bash
@@ -202,7 +229,7 @@ export TCGA_MAX_WORKERS=128
 
 - Databricks workspace (AWS or Azure)
 - Unity Catalog enabled
-- Databricks CLI configured
+- Databricks CLI **v0.297+** configured (older versions fail to download Terraform due to an expired signing key)
 - Python 3.8+
 
 ## License

--- a/config.json
+++ b/config.json
@@ -17,6 +17,7 @@
     "timeout_seconds": 900
   },
   "compute": {
+    "use_serverless": false,
     "download_node_type": "m5d.16xlarge",
     "etl_node_type": "r5d.2xlarge",
     "analysis_node_type": "r5d.xlarge"

--- a/databricks.yml
+++ b/databricks.yml
@@ -82,6 +82,38 @@ targets:
       # Override via --var flag if needed: databricks bundle deploy --var="catalog_name=my_catalog"
       pipeline_development_mode: true
 
+  # Serverless variant of dev: runs notebook tasks on serverless compute instead of
+  # classic job clusters. Selected by deploy.py when config.compute.use_serverless=true
+  # (or --serverless flag). The DLT pipeline is already serverless in pipelines.yml.
+  dev-serverless:
+    mode: development
+    workspace:
+      root_path: ~/.bundle/${bundle.name}/${bundle.target}
+      profile: HLS
+    variables:
+      pipeline_development_mode: true
+    resources:
+      jobs:
+        tcga_data_workflow:
+          # Blank job_cluster_key on each notebook task so the task runs on
+          # serverless notebook compute (Databricks auto-selects sizing).
+          # Classic job_clusters defined in resources/jobs.yml remain defined
+          # but unused — Databricks only provisions clusters actually referenced.
+          # The DLT task (etl_pipeline) is already serverless via pipelines.yml.
+          tasks:
+            - task_key: "load_config"
+              job_cluster_key: ""
+            - task_key: "download_data"
+              job_cluster_key: ""
+            - task_key: "create_bronze_layer"
+              job_cluster_key: ""
+            - task_key: "expression_clustering"
+              job_cluster_key: ""
+        tcga_incremental_refresh:
+          tasks:
+            - task_key: "download_new_data"
+              job_cluster_key: ""
+
 # Note: Staging and production targets commented out for now
 # Uncomment and configure when ready for multi-environment deployment
 #

--- a/deploy.py
+++ b/deploy.py
@@ -10,10 +10,11 @@ This script handles the complete deployment workflow for the TCGA data pipeline:
 5. Optionally runs the deployed workflow
 
 Usage:
-    python deploy.py                    # Interactive setup and deploy
-    python deploy.py --run              # Deploy and run immediately
-    python deploy.py --config-only      # Only create config.json
-    python deploy.py --deploy-only      # Deploy without running
+    python deploy.py                         # Interactive setup and deploy
+    python deploy.py --run                   # Deploy and run immediately
+    python deploy.py --run --serverless      # Deploy+run using serverless compute
+    python deploy.py --config-only           # Only create config.json
+    python deploy.py --deploy-only           # Deploy without running
 """
 
 import json
@@ -261,31 +262,45 @@ def collect_configuration(existing_config: Optional[Dict[str, Any]] = None) -> D
     print("\n" + Colors.BOLD + "Compute Configuration" + Colors.ENDC)
     print_info(f"Configure instance types for {cloud_display}")
 
-    use_defaults = prompt_yes_no(
-        f"  Use default {cloud_display} instance types?",
-        default=True
+    use_serverless = prompt_yes_no(
+        "  Use serverless compute for notebook tasks (skips cluster provisioning)?",
+        default=bool(compute.get('use_serverless', False))
     )
 
-    if use_defaults:
-        default_types = get_default_instance_types(cloud)
-        download_node = default_types['download_node_type']
-        etl_node = default_types['etl_node_type']
-        analysis_node = default_types['analysis_node_type']
+    default_types = get_default_instance_types(cloud)
+
+    if use_serverless:
+        # Node types are not used on serverless, but keep them in config so toggling
+        # back to classic compute doesn't require re-prompting.
+        download_node = compute.get('download_node_type', default_types['download_node_type'])
+        etl_node = compute.get('etl_node_type', default_types['etl_node_type'])
+        analysis_node = compute.get('analysis_node_type', default_types['analysis_node_type'])
+        print_info("Serverless selected — node type prompts skipped.")
     else:
-        download_node = prompt_with_default(
-            "  Download cluster node type (64 cores)",
-            compute.get('download_node_type', 'r5d.16xlarge')
+        use_defaults = prompt_yes_no(
+            f"  Use default {cloud_display} instance types?",
+            default=True
         )
 
-        etl_node = prompt_with_default(
-            "  ETL cluster node type (8 cores, memory optimized)",
-            compute.get('etl_node_type', 'r5d.2xlarge')
-        )
+        if use_defaults:
+            download_node = default_types['download_node_type']
+            etl_node = default_types['etl_node_type']
+            analysis_node = default_types['analysis_node_type']
+        else:
+            download_node = prompt_with_default(
+                "  Download cluster node type (64 cores)",
+                compute.get('download_node_type', 'r5d.16xlarge')
+            )
 
-        analysis_node = prompt_with_default(
-            "  Analysis cluster node type (4 cores)",
-            compute.get('analysis_node_type', 'r5d.xlarge')
-        )
+            etl_node = prompt_with_default(
+                "  ETL cluster node type (8 cores, memory optimized)",
+                compute.get('etl_node_type', 'r5d.2xlarge')
+            )
+
+            analysis_node = prompt_with_default(
+                "  Analysis cluster node type (4 cores)",
+                compute.get('analysis_node_type', 'r5d.xlarge')
+            )
 
     # Build configuration
     config = {
@@ -307,6 +322,7 @@ def collect_configuration(existing_config: Optional[Dict[str, Any]] = None) -> D
             "timeout_seconds": 300
         },
         "compute": {
+            "use_serverless": use_serverless,
             "download_node_type": download_node,
             "etl_node_type": etl_node,
             "analysis_node_type": analysis_node
@@ -505,6 +521,10 @@ def deploy_bundle(config: Dict[str, Any], repo_root: Path) -> bool:
 
         print_success(f"DLT pipeline will run as: {username}")
 
+        # Select bundle target based on compute mode
+        target = get_bundle_target(config)
+        print_info(f"Bundle target: {target}")
+
         # Build var flags for deployment
         var_flags = [
             '--var', f'catalog_name={config["lakehouse"]["catalog"]}',
@@ -512,15 +532,19 @@ def deploy_bundle(config: Dict[str, Any], repo_root: Path) -> bool:
             '--var', f'volume_name={config["lakehouse"]["volume"]}',
             '--var', f'user_name={username}',
             '--var', f'max_workers={config["pipeline"]["max_workers"]}',
-            '--var', f'download_node_type={config["compute"]["download_node_type"]}',
-            '--var', f'etl_node_type={config["compute"]["etl_node_type"]}',
-            '--var', f'analysis_node_type={config["compute"]["analysis_node_type"]}'
         ]
+        # Node type vars are only relevant for classic clusters
+        if not config['compute'].get('use_serverless', False):
+            var_flags += [
+                '--var', f'download_node_type={config["compute"]["download_node_type"]}',
+                '--var', f'etl_node_type={config["compute"]["etl_node_type"]}',
+                '--var', f'analysis_node_type={config["compute"]["analysis_node_type"]}',
+            ]
 
         # Validate bundle
         print_info("Validating bundle configuration...")
         result = subprocess.run(
-            ['databricks', 'bundle', 'validate', '--target', 'dev'] + var_flags,
+            ['databricks', 'bundle', 'validate', '--target', target] + var_flags,
             cwd=repo_root,
             capture_output=True,
             text=True
@@ -536,7 +560,7 @@ def deploy_bundle(config: Dict[str, Any], repo_root: Path) -> bool:
         # Deploy bundle
         print_info("Deploying bundle to Databricks workspace...")
         result = subprocess.run(
-            ['databricks', 'bundle', 'deploy', '--target', 'dev'] + var_flags,
+            ['databricks', 'bundle', 'deploy', '--target', target] + var_flags,
             cwd=repo_root,
             capture_output=False,  # Show output in real-time
             text=True
@@ -550,7 +574,7 @@ def deploy_bundle(config: Dict[str, Any], repo_root: Path) -> bool:
 
         # Get deployment info
         result = subprocess.run(
-            ['databricks', 'bundle', 'summary', '--target', 'dev'],
+            ['databricks', 'bundle', 'summary', '--target', target],
             cwd=repo_root,
             capture_output=True,
             text=True
@@ -567,14 +591,20 @@ def deploy_bundle(config: Dict[str, Any], repo_root: Path) -> bool:
         return False
 
 
-def run_workflow(repo_root: Path) -> bool:
+def get_bundle_target(config: Dict[str, Any]) -> str:
+    """Return the bundle target name based on compute.use_serverless."""
+    return 'dev-serverless' if config.get('compute', {}).get('use_serverless', False) else 'dev'
+
+
+def run_workflow(repo_root: Path, config: Dict[str, Any]) -> bool:
     """Run the deployed workflow"""
     try:
         print_header("Running Workflow")
 
-        print_info("Starting TCGA data workflow...")
+        target = get_bundle_target(config)
+        print_info(f"Starting TCGA data workflow (target: {target})...")
         result = subprocess.run(
-            ['databricks', 'bundle', 'run', 'tcga_data_workflow', '--target', 'dev'],
+            ['databricks', 'bundle', 'run', 'tcga_data_workflow', '--target', target],
             cwd=repo_root,
             capture_output=False,  # Show output in real-time
             text=True
@@ -599,10 +629,11 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  python deploy.py                  # Interactive setup and deploy
-  python deploy.py --run            # Deploy and run immediately
-  python deploy.py --config-only    # Only create config.json
-  python deploy.py --non-interactive # Use existing config.json (fail if not found)
+  python deploy.py                      # Interactive setup and deploy
+  python deploy.py --run                # Deploy and run immediately
+  python deploy.py --run --serverless   # Deploy+run using serverless compute
+  python deploy.py --config-only        # Only create config.json
+  python deploy.py --non-interactive    # Use existing config.json (fail if not found)
         """
     )
 
@@ -622,6 +653,13 @@ Examples:
         '--run',
         action='store_true',
         help='Deploy and run the workflow immediately'
+    )
+
+    parser.add_argument(
+        '--serverless',
+        action='store_true',
+        help='Use serverless compute for notebook tasks (skips classic cluster provisioning). '
+             'Persists compute.use_serverless=true in config.json.'
     )
 
     parser.add_argument(
@@ -675,6 +713,12 @@ Examples:
             config = collect_configuration()
             save_config(config, config_path)
 
+    # --serverless flag overrides config and persists the choice
+    if args.serverless and not config.get('compute', {}).get('use_serverless', False):
+        config.setdefault('compute', {})['use_serverless'] = True
+        save_config(config, config_path)
+        print_info("--serverless flag set: compute.use_serverless=true persisted to config.json")
+
     # Display configuration summary
     print("\n" + Colors.BOLD + "Configuration Summary:" + Colors.ENDC)
     print(f"  Catalog: {config['lakehouse']['catalog']}")
@@ -682,9 +726,15 @@ Examples:
     print(f"  Volume: {config['lakehouse']['volume']}")
     print(f"  Profile: {config['deployment']['profile']}")
     print(f"  Cloud: {config['deployment']['cloud'].upper()}")
-    print(f"  Download node: {config['compute']['download_node_type']}")
-    print(f"  ETL node: {config['compute']['etl_node_type']}")
-    print(f"  Analysis node: {config['compute']['analysis_node_type']}")
+    if config['compute'].get('use_serverless', False):
+        print(f"  Compute: {Colors.GREEN}serverless{Colors.ENDC} (bundle target: dev-serverless)")
+        print_warning("  Note: download task normally uses a 64-core single node for parallel HTTP fetches;")
+        print_warning("        on serverless, sizing is auto-selected and throughput may differ.")
+    else:
+        print(f"  Compute: classic clusters (bundle target: dev)")
+        print(f"  Download node: {config['compute']['download_node_type']}")
+        print(f"  ETL node: {config['compute']['etl_node_type']}")
+        print(f"  Analysis node: {config['compute']['analysis_node_type']}")
 
     if args.config_only:
         print_success("Configuration complete!")
@@ -710,11 +760,12 @@ Examples:
             default=True
         )
         if run_now:
-            run_workflow(repo_root)
+            run_workflow(repo_root, config)
 
     print_header("Deployment Complete!")
+    target = get_bundle_target(config)
     print_info("Next steps:")
-    print("  1. Monitor workflows: databricks bundle run tcga_data_workflow --target dev")
+    print(f"  1. Monitor workflows: databricks bundle run tcga_data_workflow --target {target}")
     print("  2. View logs in Databricks UI")
     print(f"  3. Data will be stored in: {config['lakehouse']['catalog']}.{config['lakehouse']['schema']}")
 


### PR DESCRIPTION
## Summary
- Adds `compute.use_serverless` to `config.json` and a new `--serverless` flag on `deploy.py` that persists the choice and swaps the bundle target at deploy/run time.
- Introduces a `dev-serverless` bundle target in `databricks.yml` that overrides notebook tasks in `tcga_data_workflow` and `tcga_incremental_refresh` to run on serverless notebook compute (the DLT pipeline was already serverless).
- Classic `dev` target is unchanged — users on classic clusters see no behavior change.

## Test plan
- [x] `databricks bundle validate --target dev` — passes
- [x] `databricks bundle validate --target dev-serverless` — passes
- [x] `databricks bundle deploy --target dev-serverless` — jobs created; Jobs API confirms notebook tasks have no cluster assignment (serverless notebook compute)
- [x] End-to-end run of `tcga_data_workflow` on serverless (long-running download; opt-in)
- [x] Spot-check `python deploy.py --run --serverless` interactive flow

## Notes
- DABs list-merge semantics mean classic `job_clusters` defs from `resources/jobs.yml` still appear in the resolved bundle under `dev-serverless`, but no task references them — Databricks only provisions clusters actually referenced.
- The download task normally uses a 64-core single-node cluster for parallel HTTP fetches against the GDC API; on serverless, sizing is auto-selected and throughput may differ. The CLI warns about this when `--serverless` is set.
- CLI v0.297+ is required to deploy (older versions hit a Terraform signing-key expiry). Smoke-tested with CLI v0.297.2.